### PR TITLE
Develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,10 @@ script:
   - pytest
 
 
-# Part of the attempt to fix the HDF linking problem - no luck
-#env:
-#  global:
-#    - HDF_DIR=/usr/lib/x86_64-linux-gnu/hdf5/serial
-#    - CPPFLAGS=-I/usr/include/hdf5/serial
-#    - LDFLAGS=-L/usr/lib/x86_64-linux-gnu/hdf5/serial
+env:
+ global:
+   - INCLUDE_DIRS=$(PYTHON_INCLUDE):/usr/local/include:/usr/include/hdf5/serial
+   - LIBRARY_DIRS=$(PYTHON_LIB):/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu/hdf5/serial
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ script:
 
 env:
  global:
-   - INCLUDE_DIRS=${PYTHON_INCLUDE}:/usr/local/include:/usr/include/hdf5/serial:/usr/include
-   - LIBRARY_DIRS=${PYTHON_LIB}:/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu/hdf5/serial:/usr/lib/x86_64-linux-gnu
-   - HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/serial:/usr/lib/x86_64-linux-gnu:/usr/include/hdf5/serial:/usr/include
+   - INCLUDE_DIRS=${PYTHON_INCLUDE}:/usr/local/include:/usr/include/hdf5/serial:/usr/include:/usr/lib/x86_64-linux-gnu/hdf5/serial/lib/include
+   - LIBRARY_DIRS=${PYTHON_LIB}:/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu/hdf5/serial:/usr/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu/hdf5/serial/lib/lib
+   - HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/serial:/usr/include/hdf5/serial:/usr/include:/usr/lib/x86_64-linux-gnu/hdf5/serial/lib/include:/usr/lib/x86_64-linux-gnu/hdf5/serial/lib/lib
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ before_install:
   - sudo apt-get install -y libhdf5-dev
 
 install:
+  - echo $HDF5_DIR
+  - echo $LIBRARY_DIRS
+  - echo `dpkg -L libhdf5-dev`
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,19 +22,16 @@ before_install:
   - sudo apt-get install -y libhdf5-dev
 
 install:
-  - echo $HDF5_DIR
-  - echo $LIBRARY_DIRS
-  - echo `dpkg -L libhdf5-dev`
-  - python setup.py install
+  - python setup.py install --hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/
 
 script:
   - pytest
 
 env:
  global:
-   - INCLUDE_DIRS=${PYTHON_INCLUDE}:/usr/local/include:/usr/include/hdf5/serial:/usr/include:/usr/lib/x86_64-linux-gnu/hdf5/serial/lib/include
-   - LIBRARY_DIRS=${PYTHON_LIB}:/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu/hdf5/serial:/usr/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu/hdf5/serial/lib/lib
-   - HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/serial:/usr/include/hdf5/serial:/usr/include:/usr/lib/x86_64-linux-gnu/hdf5/serial/lib/include:/usr/lib/x86_64-linux-gnu/hdf5/serial/lib/lib
+   - INCLUDE_DIRS=${PYTHON_INCLUDE}:/usr/local/include:/usr/include/hdf5/serial:/usr/include
+   - LIBRARY_DIRS=${PYTHON_LIB}:/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu/hdf5/serial
+   - HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/serial
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,14 @@ install:
 script:
   - pytest
 
-
 env:
  global:
-   - INCLUDE_DIRS=$(PYTHON_INCLUDE):/usr/local/include:/usr/include/hdf5/serial
-   - LIBRARY_DIRS=$(PYTHON_LIB):/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu/hdf5/serial
+   - INCLUDE_DIRS=${PYTHON_INCLUDE}:/usr/local/include:/usr/include/hdf5/serial
+   - LIBRARY_DIRS=${PYTHON_LIB}:/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu/hdf5/serial
 
 jobs:
   allow_failures:
     - python: "3.2"
     - python: "3.3"
     - python: "3.4"
+    - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - sudo apt-get install -y libhdf5-dev
 
 install:
-  - python setup.py install --hdf5=/usr/lib/x86_64-linux-gnu/hdf5/serial/
+  - HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/serial/ python setup.py install
 
 script:
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ dist: xenial
 language: python
 
 python:
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -21,6 +19,7 @@ branches:
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y "libhdf5-[[:digit:]]*"
+  - sudo apt-get install -y libhdf5-dev
 
 install:
   - python setup.py install
@@ -30,12 +29,11 @@ script:
 
 env:
  global:
-   - INCLUDE_DIRS=${PYTHON_INCLUDE}:/usr/local/include:/usr/include/hdf5/serial
-   - LIBRARY_DIRS=${PYTHON_LIB}:/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu/hdf5/serial
+   - INCLUDE_DIRS=${PYTHON_INCLUDE}:/usr/local/include:/usr/include/hdf5/serial:/usr/include
+   - LIBRARY_DIRS=${PYTHON_LIB}:/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu/hdf5/serial:/usr/lib/x86_64-linux-gnu
+   - HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/serial:/usr/lib/x86_64-linux-gnu:/usr/include/hdf5/serial:/usr/include
 
 jobs:
   allow_failures:
-    - python: "3.2"
-    - python: "3.3"
     - python: "3.4"
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ branches:
   - master
 
 before_install:
-  - sudo apt-get install -y libhdf5-10
+  - sudo apt-get update
+  - sudo apt-get install -y "libhdf5-[[:digit:]]*"
 
 install:
   - python setup.py install

--- a/environments/sciddo_env.yml
+++ b/environments/sciddo_env.yml
@@ -12,3 +12,4 @@ dependencies:
   - pytables=3.4.*
   - hdf5=1.8.*
   - pytest=3.2.*
+  - cython=0.29

--- a/environments/sciddo_env.yml
+++ b/environments/sciddo_env.yml
@@ -4,12 +4,11 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6.*
-  - numpy=1.13.*
-  - pandas=0.20.*
-  - scipy=0.19.*
-  - mpmath=0.19.*
-  - intervaltree=2.1.*
-  - pytables=3.4.*
+  - numpy=1.13.1
+  - pandas=0.20.3
+  - scipy=0.19.1
+  - mpmath=0.19
+  - intervaltree=2.1.0
+  - pytables=3.4.2
   - hdf5=1.8.*
   - pytest=3.2.*
-  - cython=0.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy>=1.13.1
-scipy>=0.19.1
-pandas>=0.20.3
-mpmath>=0.19
-tables>=3.4.2
-intervaltree>=2.1.0
-cython>=0.29
+numpy==1.13.1
+scipy==0.19.1
+pandas==0.20.3
+mpmath==0.19
+tables==3.4.2
+intervaltree==2.1.0
+cython==0.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ pandas==0.20.3
 mpmath==0.19
 tables==3.4.2
 intervaltree==2.1.0
-cython==0.29

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas>=0.20.3
 mpmath>=0.19
 tables>=3.4.2
 intervaltree>=2.1.0
+cython>=0.29

--- a/src/scidlib/cmd_score.py
+++ b/src/scidlib/cmd_score.py
@@ -608,7 +608,11 @@ def set_background_state(args):
     else:
         with pd.HDFStore(args.dataset, 'r') as hdf:
             md_state = hdf[PATH_MD_STATE]
-            bgs = int(md_state.loc[md_state['background'] == 1, 'number'][0])
+            try:
+                bgs = int(md_state.loc[md_state['background'] == 1, 'number'][0])
+            except IndexError:
+                raise ValueError('Cannot retrieve background state - '
+                                'has it been set or determined?\n{}'.format(md_state))
             args.__setattr__('bgstate', bgs)
     return args
 


### PR DESCRIPTION
allow Travis fail for Py35; problem with lib HDF setup/linking that does not occur with Py36+. SCIDDO should nevertheless work with Python 3.5